### PR TITLE
add 0 arg getInstance Method to LibPostal class

### DIFF
--- a/src/main/java/com/mapzen/jpostal/LibPostal.java
+++ b/src/main/java/com/mapzen/jpostal/LibPostal.java
@@ -30,6 +30,17 @@ final class LibPostal {
 
     private volatile static LibPostal instance = null;
 
+    static LibPostal getInstance() {
+        if (instance == null) {
+            synchronized(LibPostal.class) {
+                if (instance == null) {
+                    instance = new LibPostal(Config.builder().build());
+                }
+            }
+        }
+        return instance;
+    }
+
     static LibPostal getInstance(final Config config) {
        if (instance == null) {
             synchronized(LibPostal.class) {


### PR DESCRIPTION
This helps reuse an existing LibPostal instance when we dont know its configuration