### PR TITLE
fix segfault from parallel calls to close methods

### DIFF
--- a/src/main/java/com/mapzen/jpostal/LibPostal.java
+++ b/src/main/java/com/mapzen/jpostal/LibPostal.java
@@ -65,10 +65,10 @@ final class LibPostal {
      * Closes the singleton instance, releasing native resources and allowing re-initialization.
      */
     public static void close() {
-        // Close dependent singletons first
-        AddressParser._close();
-        AddressExpander._close();
         synchronized (LibPostal.class) {
+            // Close dependent singletons first
+            AddressParser._close();
+            AddressExpander._close();
             if (instance != null) {
                 teardown();
                 instance = null;


### PR DESCRIPTION
I was getting this SEGFAULT in wherobots-tools when running the address test suite, only in the code gen path

[hs_err_pid49137.log](https://github.com/user-attachments/files/20698750/hs_err_pid49137.log)
