### PR TITLE
use openvenues libpostal repo instead of james-willis' fork

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: openvenues/libpostal
-          ref: fix-aarch64
           path: libpostal
       - name: Install libpostal
         run: |
@@ -92,7 +91,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: openvenues/libpostal
-          ref: fix-aarch64
           path: libpostal
       - name: Install libpostal
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: openvenues/libpostal
-          ref: fix-aarch64
           path: libpostal
       - name: Install libpostal
         run: |


### PR DESCRIPTION
The changes in my fork got upstreamed to the openvenues repo so I can deprecate my fork now